### PR TITLE
Add: Cnn For Sentence Classification

### DIFF
--- a/NLP/CnnForSentenceClassification/datamodule.py
+++ b/NLP/CnnForSentenceClassification/datamodule.py
@@ -1,0 +1,49 @@
+from torch.utils.data import Dataset
+from pytorch_lightning import LightningDataModule
+from konlpy.tag import Mecab
+
+from torchtext.legacy import data
+from torchtext.legacy.data import TabularDataset, Iterator
+
+
+class NMSCtorchtextDataModule(LightningDataModule):
+    def __init__(self,
+                 batch_size=256,
+                 max_length=64):
+        super().__init__()
+        self.tokenizer = Mecab()
+        self.batch_size = batch_size
+        self.ID = data.Field(sequential=False,
+                             use_vocab=False,
+                             is_target=False)
+        self.TEXT = data.Field(sequential=True,
+                               use_vocab=True,
+                               tokenize=self.tokenizer.morphs,
+                               lower=False,
+                               batch_first=True,
+                               fix_length=max_length)
+        self.LABEL = data.Field(sequential=False,
+                                use_vocab=False,
+                                is_target=True)
+        self.train_data, self.val_data = TabularDataset.splits(path='./dataset',
+                                                               train='ratings_train.txt',
+                                                               test='ratings_test.txt',
+                                                               format='tsv',
+                                                               fields=[('id', self.ID),
+                                                                       ('text', self.TEXT),
+                                                                       ('label', self.LABEL)],
+                                                               skip_header=True)
+        self.TEXT.build_vocab(self.train_data, min_freq=5)
+
+    def __len__(self):
+        return len(self.TEXT.vocab)
+
+    def train_dataloader(self):
+        return Iterator(dataset=self.train_data,
+                        batch_size=self.batch_size,
+                        shuffle=True)
+
+    def val_dataloader(self):
+        return Iterator(dataset=self.val_data,
+                        batch_size=self.batch_size,
+                        shuffle=False)

--- a/NLP/CnnForSentenceClassification/model.py
+++ b/NLP/CnnForSentenceClassification/model.py
@@ -1,0 +1,54 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class CNNClassifier(nn.Module):
+    def __init__(self,
+                 n_words,
+                 wordvec_dim=512,
+                 drop_out=.5,
+                 window_size=[5, 6, 7],
+                 n_filters=[64, 64, 64]):
+        super(CNNClassifier, self).__init__()
+
+        self.wordvec_dim = wordvec_dim
+        self.window_size = window_size
+        self.n_filters = n_filters
+        self.min_length = max(self.window_size)
+
+        assert len(self.window_size) == len(self.n_filters), f"window와 filter의 갯수를 맞춰주세요,,\
+        {len(self.n_filters)} != {len(self.window_size)}"
+
+        self.emb = nn.Embedding(n_words, wordvec_dim)
+
+        for window, filter_ in zip(window_size, n_filters):
+            cnn = nn.Conv2d(in_channels=1,
+                            out_channels=filter_,
+                            kernel_size=(window, wordvec_dim))
+            setattr(self, f'cnn-w{window}-f{filter_}', cnn)
+
+        self.drop_out = nn.Dropout(drop_out)
+        self.tanh = nn.Tanh()
+        self.fc = nn.Sequential(
+            nn.BatchNorm1d(sum(n_filters)),
+            nn.ReLU(),
+            nn.Linear(sum(n_filters), 2)
+        )
+
+    def forward(self, x):
+        word_vec = self.emb(x)
+        word_vec_pad = word_vec.unsqueeze(1)
+
+        c = []
+        for window, filter_ in zip(self.window_size, self.n_filters):
+            cnn = getattr(self, f'cnn-w{window}-f{filter_}')
+            cnn_out = self.tanh(cnn(word_vec_pad))
+            drop_out = self.drop_out(cnn_out)
+            c_i = F.max_pool1d(input=drop_out.squeeze(-1),
+                               kernel_size=drop_out.size(-2)).squeeze(-1)
+            c.append(c_i)
+
+        cnn_result = torch.cat(c, dim=-1)
+        logit = self.fc(cnn_result)
+        return logit

--- a/NLP/CnnForSentenceClassification/train.py
+++ b/NLP/CnnForSentenceClassification/train.py
@@ -1,0 +1,54 @@
+# 필요한 모듈을 임포트합니다.
+from pytorch_lightning import Trainer
+
+from pytorch_lightning.loggers import TensorBoardLogger
+from pytorch_lightning.callbacks.early_stopping import EarlyStopping
+from pytorch_lightning.callbacks import ModelCheckpoint
+
+from trainmodule import Classifier
+from datamodule import NMSCtorchtextDataModule
+
+import warnings
+warnings.filterwarnings('ignore')
+
+
+# 작성해두었던 모듈들을 가져옵니다.
+network = Classifier()
+datamodule = NMSCtorchtextDataModule()
+
+# Logger를 선언합니다.
+logger = TensorBoardLogger(
+                           save_dir="classification_logs",  # 로그 파일들이 저장될 경로
+                           name="CnnForSentenceClf",  # 로그 데이터의 이름
+                           default_hp_metric=False,
+                           )
+
+# 체크포인트 콜백함수를 선언합니다.
+checkpoint_callback = ModelCheckpoint(
+                                     monitor='Accuracy',  # 어떤 지표를 기준으로 삼을 것인지
+                                     dirpath='classification_ckpt',  # 체크포인트 파일들이 저장될 경로
+                                     filename='CnnForSentenceClf',  # 체크포인트 파일의 이름(확장자 불요)
+                                     mode='max'  # 위 지표가 최대일 때의 모델을 저장(min으로 설정 가능)
+                                     )
+
+# early stopping 콜백함수를 선언합니다.
+early_stop_callback = EarlyStopping(
+                                    monitor='Accuracy',  # 어떤 지표를 기준으로 삼을 것인지
+                                    min_delta=1e-4,  # 위 지표가 얼마나 향상이 되어야 하는지
+                                    patience=20,  # 몇 에포크동안 지켜볼 것인지
+                                    mode='max'
+                                    )
+
+
+# trainer를 선언합니다.
+trainer = Trainer(max_epochs=100,  # 최대 에포크
+                  gpus=4,  # 학습에 사용할 GPU의 갯수
+                  accelerator='ddp',
+                  callbacks=[early_stop_callback,
+                             checkpoint_callback],  # 위에서 선언했던 콜백함수들
+                  logger=logger  # 위에서 선언한 Logger
+                  )
+
+if __name__ == '__main__':
+    # 학습 시작
+    trainer.fit(network=network, datamodule=datamodule)

--- a/NLP/CnnForSentenceClassification/trainmodule.py
+++ b/NLP/CnnForSentenceClassification/trainmodule.py
@@ -1,0 +1,50 @@
+import torch.nn as nn
+import torch.optim as optim
+
+from pytorch_lightning import LightningModule
+
+from model import CNNClassifier
+
+from torchmetrics import Accuracy
+
+
+class Classifier(LightningModule):
+    def __init__(self,
+                 model=None,
+                 n_words=None,
+                 lr=1e-4):
+        super(Classifier, self).__init__()
+
+        self.model = CNNClassifier(n_words=n_words)
+
+        self.lr = lr
+        self.loss_fn = nn.CrossEntropyLoss()
+        self.metrics = Accuracy()
+
+    def configure_optimizers(self):
+        return optim.AdamW(params=self.model.parameters(),
+                           lr=self.lr)
+
+    def forward(self, x):
+        return self.model(x)
+    
+    def step(self, batch, is_train=True):
+        x, y = batch.text, batch.label
+        y_hat = self(x)
+        
+        if not is_train:
+            self.metrics(preds=y_hat, target=y)
+        
+        return self.loss_fn(y_hat, y)
+
+    def training_step(self, batch, *args, **kwargs):
+        loss = self.step(batch)
+        self.log('train_loss_step', loss, on_step=True, on_epoch=False, prog_bar=False)
+        self.log('train_loss_epoch', loss, on_step=False, on_epoch=True, prog_bar=False)
+        return {'loss': loss}
+
+    def validation_step(self, batch, *args, **kwargs):
+        loss = self.step(batch)
+        self.log('val_loss', loss, on_step=False, on_epoch=True, prog_bar=False)
+        self.log('Accuracy', self.metrics, on_step=False, on_epoch=True, prog_bar=False)
+        return {'loss': loss}


### PR DESCRIPTION
자연어 처리에는 RNN계열 모델을 사용하는 것이 일반적이었습니다.

같은 단어라 하더라도 context에 따라 듯이 완전히 달라질 수 있는 등의 이유때문인데요

2014년 뉴욕대 김윤 교수님의 Convolutional Neural Networks for Sentence Classification(arXiv:1408.5882) 논문을 통해

그 패러다임을 바꿀 수 있었습니다.

어찌 보면 현재 자연어 처리 분야를 휩쓸고 있는 트랜스포머 기반 모델(BERT, GPT etc.)의 주요 선행연구라고도 할 수 있겠습니다.

한 번 살펴보도록 하죠

